### PR TITLE
fix: grep -P substitution with perl templating

### DIFF
--- a/koch
+++ b/koch
@@ -30,7 +30,7 @@ function gettoken {
 	else
 		add_comm=" --no-insecure "
 	fi
-	curl -s --fail $add_comm --request GET  -u "$user:$pass" --header "X-CSRF-Token: xxx" --url "$host/oauth/authorize?response_type=token&client_id=openshift-challenging-client" --head | grep -i Location | grep -o -P '(?<=implicit#access_token=).*(?=&expires_in)' 
+	curl -s --fail $add_comm --request GET  -u "$user:$pass" --header "X-CSRF-Token: xxx" --url "$host/oauth/authorize?response_type=token&client_id=openshift-challenging-client" --head | grep -i Location | perl -nle'print $& while m{(?<=implicit#access_token=).*(?=&expires_in)}g' 
 }
 
 function login {


### PR DESCRIPTION
grep -P substitution with perl templating to support macos shell: https://stackoverflow.com/questions/16658333/grep-p-no-longer-works-how-can-i-rewrite-my-searches