### PR TITLE
fix BW newline handling

### DIFF
--- a/koch
+++ b/koch
@@ -146,8 +146,8 @@ function login_action {
 			echo "log: $item" >&2
 			exit 11
 		fi
-		user=$(echo $item | jq -r '.login.username')
-		pass=$(echo $item | jq -r '.login.password')
+		user=$(printf "%s" "$item" | jq -r '.login.username')
+		pass=$(printf "%s" "$item" | jq -r '.login.password')
 	else
 		echo "Secret method $secrethandler not found"
 		exit 12


### PR DESCRIPTION
In case of presence of the symbol "\n" in response from BW jq crashes if you use `echo` to print response:
`jq: parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 2, column 1`.

Using `printf "%s"` is better than using echo in scripts where consistency and predictability regarding newline and other special characters are necessary. Quoting variable is good practice in sh.